### PR TITLE
Make dependencies less restrictive

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,17 +3,17 @@
   "version": "0.0.3",
   "main": "dist/contenteditable.js",
   "dependencies": {
-    "angular": "1.2.4",
-    "json3": "~3.2.4",
-    "es5-shim": "~2.1.0",
-    "angular-resource": "1.2.4",
-    "angular-cookies": "1.2.4",
-    "angular-sanitize": "1.2.4",
-    "angular-route": "1.2.4"
+    "angular": "~1.2",
+    "json3": "~3.2",
+    "es5-shim": "~2.1",
+    "angular-resource": "~1.2",
+    "angular-cookies": "~1.2",
+    "angular-sanitize": "~1.2",
+    "angular-route": "~1.2"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.4",
-    "angular-scenario": "1.2.4",
-    "jquery": "~1.10.2"
+    "angular-mocks": "~1.2",
+    "angular-scenario": "~1.2",
+    "jquery": "~1.10"
   }
 }


### PR DESCRIPTION
Allow installing this directive without being constrained to use angular specific version 1.2.4.
